### PR TITLE
rename download scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,7 @@ Dependancies:  acpica, virtualbox-kernel
 The SlackBuilds here are just modified versions from slackbuilds.org
 
 To download the need source files run this: (in each folder)
-<pre>
-./downloads_needed.txt
+
+```
+./download_needed.sh
+```

--- a/virtualbox-6.1.4/virtualbox-extension-pack/download_needed.sh
+++ b/virtualbox-6.1.4/virtualbox-extension-pack/download_needed.sh
@@ -1,1 +1,3 @@
+#!/usr/bin/bash
+
 wget https://download.virtualbox.org/virtualbox/6.1.4/Oracle_VM_VirtualBox_Extension_Pack-6.1.4.vbox-extpack

--- a/virtualbox-6.1.4/virtualbox/download_needed.sh
+++ b/virtualbox-6.1.4/virtualbox/download_needed.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/bash
+
 wget https://download.virtualbox.org/virtualbox/6.1.4/VBoxGuestAdditions_6.1.4.iso
 wget https://download.virtualbox.org/virtualbox/6.1.4/VirtualBox-6.1.4.tar.bz2
 wget http://download.virtualbox.org/virtualbox/6.1.4/UserManual.pdf


### PR DESCRIPTION
This is more or less cosmetic change, however I find it odd to name executable file with postfix `.txt`.

I think calling this script `download_needed.sh` is better because it shows intent of the script more clearly.